### PR TITLE
Retry backoff

### DIFF
--- a/speedflux/influx.py
+++ b/speedflux/influx.py
@@ -25,7 +25,7 @@ class Influx:
             speedflux.LOG.debug("Client extablished")
         return self._client
 
-    def init_db(self, backoff_in_seconds = 1):
+    def init_db(self, backoff_in_seconds = 2):
 
         try:
             speedflux.LOG.debug("Intitializing Influx Database")


### PR DESCRIPTION
Incorporate Selta's retry backoff

> Currently, when running with an influx DB that starts in another container, the Speedflux will complete its 3 retries before the influxDB is accepting connections. This PR adds a simple exponential backoff to those retries, allowing influxDB a little more time (~28seconds with the default 2s backoff_in_seconds param) to start and accept connections.